### PR TITLE
debain/storagenode: require network-online.target to start

### DIFF
--- a/packaging/debian/storagenode-updater.service
+++ b/packaging/debian/storagenode-updater.service
@@ -12,7 +12,7 @@
 
 [Unit]
 Description  = Storage Node Updater service
-After        = syslog.target
+After        = syslog.target network.target
 
 [Service]
 Type         = simple

--- a/packaging/debian/storagenode.service
+++ b/packaging/debian/storagenode.service
@@ -13,6 +13,8 @@
 [Unit]
 Description  = Storage Node service
 After        = syslog.target
+After        = network-online.target
+Wants        = network-online.target
 
 [Service]
 Type         = simple

--- a/packaging/debian/storagenode.service
+++ b/packaging/debian/storagenode.service
@@ -12,9 +12,7 @@
 
 [Unit]
 Description  = Storage Node service
-After        = syslog.target
-After        = network-online.target
-Wants        = network-online.target
+After        = syslog.target network.target
 
 [Service]
 Type         = simple


### PR DESCRIPTION
Require network-online.target to start. Prevents `storagenode` from starting before host is online.