### PR TITLE
add --service-name to storagenode-updater

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -133,7 +133,7 @@ After        = syslog.target network.target
 Type         = simple
 User         = storj-storagenode
 Group        = storj-storagenode
-ExecStart    = /var/lib/storagenode/storagenode-updater run --config-dir "/etc/storagenode" --binary-location "/var/lib/storagenode/storagenode"
+ExecStart    = /var/lib/storagenode/storagenode-updater run --config-dir "/etc/storagenode" --binary-location "/var/lib/storagenode/storagenode" --service-name "storagenode"
 Restart      = on-failure
 NotifyAccess = main
 


### PR DESCRIPTION
What: Add --service-name to storagenode-updater service.

Why: I am running 6 storage node services and also 6 updater services. This little change will make it a bit more obvious how to do that.